### PR TITLE
Bound check fixes

### DIFF
--- a/src/ELSED.cpp
+++ b/src/ELSED.cpp
@@ -322,7 +322,9 @@ void ELSED::drawAnchorPoints(const uint8_t *dirImg,
           p = cv::Point2f(px.x, px.y) - perpDir * cv::Vec3f(px.x, px.y, 1).dot(l);
           // Get the values around the point p to do the bi-linear interpolation
           x0 = p.x < 0 ? 0 : p.x;
+          if (x0 >= imageWidth) x0 = imageWidth - 1;
           y0 = p.y < 0 ? 0 : p.y;
+          if (y0 >= imageHeight) y0 = imageHeight - 1;
           x1 = p.x + 1;
           if (x1 >= imageWidth) x1 = imageWidth - 1;
           y1 = p.y + 1;

--- a/src/EdgeDrawer.cpp
+++ b/src/EdgeDrawer.cpp
@@ -743,8 +743,8 @@ bool EdgeDrawer::canSegmentBeExtended(FullSegmentInfo &segment,
           // Depending on the segment extension pixels orientation, look the vertical or horizontal neighbors
           xOffset = horizontalValidationDir ? 0 : offset;
           yOffset = horizontalValidationDir ? offset : 0;
-          indexInArray = std::min(imageHeight, std::max(0, extPixel.y + yOffset)) * imageWidth
-              + std::min(imageWidth, std::max(0, extPixel.x + xOffset));
+          indexInArray = std::min(imageHeight-1, std::max(0, extPixel.y + yOffset)) * imageWidth
+              + std::min(imageWidth-1, std::max(0, extPixel.x + xOffset));
 
           a += pDxImg[indexInArray] * pDxImg[indexInArray];
           b += pDxImg[indexInArray] * pDyImg[indexInArray];


### PR DESCRIPTION
I've been testing ELSED on a video sequence and discovered a couple of memory overrun errors. They were all caused by wrong or missing bound checks which I have fixed here.