### PR TITLE
Adding the MANIFEST.in file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include CMakeLists.txt
+recursive-include pybind11 *
+recursive-include src *


### PR DESCRIPTION
Added the MANIFEST.in file to allow the build of a distribution archive.

In order for the build to work (`python3 -m build`), it is necessary to explicitly indicate to include the CMakeLists.txt, the [pybind11](https://github.com/pybind/pybind11) git submodule and the src/ directory. 