### PR TITLE
Fix out-of-bounds read / crash in drawAnchorPoints on degenerate (NaN) segments

### DIFF
--- a/src/ELSED.cpp
+++ b/src/ELSED.cpp
@@ -320,6 +320,14 @@ void ELSED::drawAnchorPoints(const uint8_t *dirImg,
           // units (the distance between the pixel and the segment) in the direction
           // perpendicular to the segment (perpDir).
           p = cv::Point2f(px.x, px.y) - perpDir * cv::Vec3f(px.x, px.y, 1).dot(l);
+          // A segment whose two boundary pixels collapse to one has coincident endpoints, so
+          // the line above (their cross product) is a zero vector and normalizing it is
+          // 0/0 = NaN. The NaN reprojected point survives the clamps below (NaN < 0 is false)
+          // and converts to an out-of-range int index (INT_MIN on x86), reading the gradient
+          // array out of bounds and crashing (see issue #13). Stopgap: skip the NaN pixel so
+          // the degenerate segment collects zero inliers and is dropped; the endpoint
+          // bookkeeping that lets firstPx == lastPx happen is the real cause (#13 / #15).
+          if (p.x != p.x || p.y != p.y) continue;
           // Get the values around the point p to do the bi-linear interpolation
           x0 = p.x < 0 ? 0 : p.x;
           if (x0 >= imageWidth) x0 = imageWidth - 1;


### PR DESCRIPTION
Fixes the access-violation crash reported in #16.

On some images a segment's two tracked boundary pixels (`firstPx`, `lastPx`) collapse to the same pixel, so `calcSegmentEndpoints` projects both onto one point and the segment's endpoints coincide. The line from those endpoints (their cross product) is a zero vector; normalizing it is 0/0 = NaN, which propagates to the reprojected point, survives the index clamps (`NaN < 0` is false), and becomes an out-of-range `int` index (INT_MIN on x86) — an out-of-bounds gradient read that crashes.

This PR is a **stopgap**: one guard that skips a NaN reprojected pixel, so a fully-degenerate segment collects zero orientation inliers and is dropped — no valid segment is affected. It does **not** fix the underlying cause: the endpoint bookkeeping in the edge/junction extension that lets `firstPx == lastPx` happen (same area as #13 Bug #2 / #15). A fix there would remove the degenerate segment at the source; happy to help if useful.
